### PR TITLE
Fixed multiselect not working for fzf-lua picker.

### DIFF
--- a/lua/UNL/backend/picker/provider/fzf_lua.lua
+++ b/lua/UNL/backend/picker/provider/fzf_lua.lua
@@ -10,7 +10,7 @@ end
 function M.run(spec)
   spec = spec or {}
   local source = spec.source or { type = "static", items = spec.items }
-  
+
   if source.type == "static" then
     return M.run_static(spec, source)
   elseif source.type == "grep" then
@@ -23,7 +23,9 @@ function M.run(spec)
 end
 
 local function normalize_path(p)
-  if not p then return nil end
+  if not p then
+    return nil
+  end
   return p:gsub("\\", "/"):gsub("//+", "/")
 end
 
@@ -34,7 +36,7 @@ end
 -- 汎用的なパス抽出ロジック (Display文字列から実パスを取り出す)
 local function extract_path_from_entry(entry, lookup, cwd)
   local path, line, col
-  
+
   -- 1. ルックアップテーブルにあるか確認 (static用)
   if lookup and lookup[entry] then
     path, line, col = lookup[entry].filename, lookup[entry].lnum, lookup[entry].col
@@ -55,27 +57,28 @@ local function extract_path_from_entry(entry, lookup, cwd)
       path = cwd .. "/" .. path
     end
   end
-  
+
   return path, line, col
 end
 
 function M.run_static(spec, source)
   local fzf = require("fzf-lua")
   local builtin = require("fzf-lua.previewer.builtin")
-  
+
   local display_items = {}
   local lookup = {}
   local cwd = get_safe_cwd(spec.cwd)
 
   for _, item in ipairs(source.items or {}) do
     local value, display, filename, lnum, col
-    if type(item) == 'table' then
+    if type(item) == "table" then
       value, display = item.value or item, item.display or item.label or item.name or tostring(item.value or item)
-      filename, lnum, col = normalize_path(item.filename or item.file_path), item.lnum or item.line or item.row, item.col
+      filename, lnum, col =
+        normalize_path(item.filename or item.file_path), item.lnum or item.line or item.row, item.col
     else
       value, display, filename = item, tostring(item), normalize_path(tostring(item))
     end
-    
+
     lookup[display] = { value = value, filename = filename, lnum = tonumber(lnum), col = tonumber(col) }
     table.insert(display_items, display)
   end
@@ -83,23 +86,38 @@ function M.run_static(spec, source)
   local opts = {
     prompt = spec.title or "Select Item> ",
     cwd = cwd,
-    multiselect = (spec.multiselect == "native" or spec.multiselect == true),
     actions = {
       ["default"] = function(selected)
-        if not selected or #selected == 0 then return end
+        if not selected or #selected == 0 then
+          return
+        end
         local results = {}
-        for _, key in ipairs(selected) do if lookup[key] then table.insert(results, lookup[key].value) end end
+        for _, key in ipairs(selected) do
+          if lookup[key] then
+            table.insert(results, lookup[key].value)
+          end
+        end
         if spec.on_confirm then
           local is_multi = (spec.multiselect == "native" or spec.multiselect == true)
-          vim.schedule(function() spec.on_confirm(is_multi and results or results[1]) end)
+          vim.schedule(function()
+            spec.on_confirm(is_multi and results or results[1])
+          end)
         end
-      end
-    }
+      end,
+    },
   }
+
+  if spec.multiselect == "native" or spec.multiselect == true then
+    opts["fzf_opts"] = { ["--multi"] = true }
+  end
 
   if spec.preview_enabled ~= false then
     local Prev = builtin.buffer_or_file:extend()
-    function Prev:new(o, opts, f_win) Prev.super.new(self, o, opts, f_win); setmetatable(self, Prev); return self end
+    function Prev:new(o, opts, f_win)
+      Prev.super.new(self, o, opts, f_win)
+      setmetatable(self, Prev)
+      return self
+    end
     function Prev:parse_entry(entry)
       local path, line, col = extract_path_from_entry(entry, lookup, cwd)
       return path and { path = path, line = line, col = col } or {}
@@ -113,11 +131,19 @@ end
 function M.run_grep(spec, source)
   local fzf = require("fzf-lua")
   local args = { "--vimgrep", "--line-number", "--column", "--smart-case", "--no-heading", "--hidden" }
-  for _, dir in ipairs(source.exclude_directories or {}) do table.insert(args, "--glob"); table.insert(args, "!" .. normalize_path(dir)) end
-  for _, ext in ipairs(source.include_extensions or {}) do table.insert(args, "-g"); table.insert(args, "*." .. ext) end
-  
+  for _, dir in ipairs(source.exclude_directories or {}) do
+    table.insert(args, "--glob")
+    table.insert(args, "!" .. normalize_path(dir))
+  end
+  for _, ext in ipairs(source.include_extensions or {}) do
+    table.insert(args, "-g")
+    table.insert(args, "*." .. ext)
+  end
+
   local search_paths = {}
-  for _, p in ipairs(source.search_paths or {}) do table.insert(search_paths, normalize_path(p)) end
+  for _, p in ipairs(source.search_paths or {}) do
+    table.insert(search_paths, normalize_path(p))
+  end
 
   fzf.live_grep({
     prompt = spec.title or "Live Grep> ",
@@ -127,13 +153,17 @@ function M.run_grep(spec, source)
     actions = {
       ["default"] = function(selected)
         local e = selected[1]
-        if not e then return end
+        if not e then
+          return
+        end
         local f, l, c = e:match("^([^:]+):(%d+):(%d+):.*$")
         if f and l and spec.on_confirm then
-          vim.schedule(function() spec.on_confirm({ filename = normalize_path(f), lnum = tonumber(l), col = tonumber(c) }) end)
+          vim.schedule(function()
+            spec.on_confirm({ filename = normalize_path(f), lnum = tonumber(l), col = tonumber(c) })
+          end)
         end
-      end
-    }
+      end,
+    },
   })
 end
 
@@ -144,15 +174,20 @@ function M.run_callback(spec, source)
 
   local fzf_fn = function(fzf_cb)
     local push = function(items)
-      if not items then return end
-      local to_add = (type(items) == "table" and items[1] ~= nil) and items or {items}
+      if not items then
+        return
+      end
+      local to_add = (type(items) == "table" and items[1] ~= nil) and items or { items }
       for _, it in ipairs(to_add) do
         -- callback時は 'value' をそのまま渡す。UEPは value に "label\tpath" を入れているため
-        local line = (type(it) == "table") and (it.value or it.display or it.label or it.filename) or tostring(it)
+        local line = (type(it) == "table") and (it.value or it.display or it.label or it.filename)
+          or tostring(it)
         fzf_cb(line)
       end
     end
-    if source.fn then source.fn(push) end
+    if source.fn then
+      source.fn(push)
+    end
   end
 
   local opts = {
@@ -160,18 +195,35 @@ function M.run_callback(spec, source)
     cwd = cwd,
     actions = {
       ["default"] = function(selected)
-        if selected and #selected > 0 and spec.on_confirm then
-          -- UEP形式のタブ区切りから実パスを抽出
-          local val = selected[1]:match("[^\t]+$") or selected[1]
-          vim.schedule(function() spec.on_confirm(val) end)
+        if not selected or #selected == 0 then
+          return
         end
-      end
-    }
+        local results = {}
+        for _, key in ipairs(selected) do
+          local val = key:match("[^\t]+$") or key
+          table.insert(results, val)
+        end
+        if spec.on_confirm then
+          local is_multi = (spec.multiselect == "native" or spec.multiselect == true)
+          vim.schedule(function()
+            spec.on_confirm(is_multi and results or results[1])
+          end)
+        end
+      end,
+    },
   }
+
+  if spec.multiselect == "native" or spec.multiselect == true then
+    opts["fzf-opts"] = { ["--multi"] = true }
+  end
 
   if spec.preview_enabled ~= false then
     local Prev = builtin.buffer_or_file:extend()
-    function Prev:new(o, opts, f_win) Prev.super.new(self, o, opts, f_win); setmetatable(self, Prev); return self end
+    function Prev:new(o, opts, f_win)
+      Prev.super.new(self, o, opts, f_win)
+      setmetatable(self, Prev)
+      return self
+    end
     function Prev:parse_entry(entry)
       -- ルックアップなしで文字列からパスを抽出
       local path, line, col = extract_path_from_entry(entry, nil, cwd)
@@ -188,20 +240,24 @@ function M.run_job(spec, source)
   local cmd = source.command
   if type(cmd) == "table" then
     local normalized_cmd = {}
-    for _, arg in ipairs(cmd) do table.insert(normalized_cmd, arg:match("[/\\]") and normalize_path(arg) or arg) end
+    for _, arg in ipairs(cmd) do
+      table.insert(normalized_cmd, arg:match("[/\\]") and normalize_path(arg) or arg)
+    end
     cmd = table.concat(normalized_cmd, " ")
   end
-  
+
   fzf.fzf_exec(cmd, {
     prompt = spec.title or "Find> ",
     cwd = get_safe_cwd(spec.cwd),
     actions = {
       ["default"] = function(selected)
         if selected and #selected > 0 and spec.on_confirm then
-          vim.schedule(function() spec.on_confirm(selected[1]) end)
+          vim.schedule(function()
+            spec.on_confirm(selected[1])
+          end)
         end
-      end
-    }
+      end,
+    },
   })
 end
 

--- a/lua/UNL/backend/picker/provider/telescope.lua
+++ b/lua/UNL/backend/picker/provider/telescope.lua
@@ -10,7 +10,7 @@ end
 function M.run(spec)
   spec = spec or {}
   local source = spec.source or { type = "static", items = spec.items }
-  
+
   if source.type == "static" then
     return M.run_static(spec, source)
   elseif source.type == "grep" then
@@ -26,11 +26,11 @@ end
 local function create_entry_maker(spec, use_devicons, devicons, make_display)
   return function(entry)
     local value, display, filename, lnum, col
-    
-    if type(entry) == 'table' then
+
+    if type(entry) == "table" then
       value = entry.value or entry
       display = entry.display or entry.label or entry.name or tostring(value)
-      filename = entry.filename or (type(value) == 'table' and value.filename)
+      filename = entry.filename or (type(value) == "table" and value.filename)
       lnum = entry.lnum or entry.line or entry.row
       col = entry.col
     else
@@ -38,7 +38,7 @@ local function create_entry_maker(spec, use_devicons, devicons, make_display)
       display = tostring(entry)
       filename = tostring(entry)
     end
-    
+
     local result = {
       value = value,
       display = display,
@@ -47,8 +47,8 @@ local function create_entry_maker(spec, use_devicons, devicons, make_display)
       lnum = lnum and tonumber(lnum),
       col = col and tonumber(col),
     }
-    
-    if use_devicons and filename and type(filename) == 'string' then
+
+    if use_devicons and filename and type(filename) == "string" then
       local extension = vim.fn.fnamemodify(filename, ":e")
       local icon, icon_hl = devicons.get_icon(filename, extension)
       result.icon = icon or (type(entry) == "table" and entry.icon) or ""
@@ -80,12 +80,14 @@ function M.run_static(spec, source)
   local displayer, make_display
   if use_devicons then
     displayer = entry_display.create({ separator = " ", items = { { width = 2 }, { remaining = true } } })
-    make_display = function(entry) return displayer({ { entry.icon, entry.icon_hl }, entry.display_text }) end
+    make_display = function(entry)
+      return displayer({ { entry.icon, entry.icon_hl }, entry.display_text })
+    end
   end
 
   local finder = finders.new_table({
     results = source.items or {},
-    entry_maker = create_entry_maker(spec, use_devicons, devicons, make_display)
+    entry_maker = create_entry_maker(spec, use_devicons, devicons, make_display),
   })
 
   local picker_opts = {
@@ -96,19 +98,33 @@ function M.run_static(spec, source)
       actions.select_default:replace(function()
         local picker = action_state.get_current_picker(prompt_bufnr)
         actions.close(prompt_bufnr)
-        local get_value = function(entry) return entry and entry.value or nil end
+        local get_value = function(entry)
+          return entry and entry.value or nil
+        end
         local is_multi = (spec.multiselect == "native" or spec.multiselect == true)
         if is_multi then
           local results = {}
-          for _, entry in ipairs(picker:get_multi_selection()) do table.insert(results, get_value(entry)) end
+          for _, entry in ipairs(picker:get_multi_selection()) do
+            table.insert(results, get_value(entry))
+          end
           if #results == 0 then
             local e = action_state.get_selected_entry()
-            if e then table.insert(results, get_value(e)) end
+            if e then
+              table.insert(results, get_value(e))
+            end
           end
-          if spec.on_confirm then vim.schedule(function() spec.on_confirm(results) end) end
+          if spec.on_confirm then
+            vim.schedule(function()
+              spec.on_confirm(results)
+            end)
+          end
         else
           local e = action_state.get_selected_entry()
-          if spec.on_confirm then vim.schedule(function() spec.on_confirm(get_value(e)) end) end
+          if spec.on_confirm then
+            vim.schedule(function()
+              spec.on_confirm(get_value(e))
+            end)
+          end
         end
       end)
       return true
@@ -117,7 +133,7 @@ function M.run_static(spec, source)
 
   if spec.preview_enabled ~= false then
     local use_grep_previewer = false
-    if spec.preview_mode == "grep" then 
+    if spec.preview_mode == "grep" then
       use_grep_previewer = true
     elseif source.items and #source.items > 0 then
       -- Check first few items for line info
@@ -136,7 +152,7 @@ function M.run_static(spec, source)
 end
 
 function M.run_grep(spec, source)
-  local builtin = require('telescope.builtin')
+  local builtin = require("telescope.builtin")
   local actions = require("telescope.actions")
   local action_state = require("telescope.actions.state")
   local make_entry = require("telescope.make_entry")
@@ -147,15 +163,19 @@ function M.run_grep(spec, source)
   local displayer, make_display
   if use_devicons then
     displayer = entry_display.create({ separator = " ", items = { { width = 2 }, { remaining = true } } })
-    make_display = function(entry) return displayer({ { entry.icon, entry.icon_hl }, entry.display_text }) end
+    make_display = function(entry)
+      return displayer({ { entry.icon, entry.icon_hl }, entry.display_text })
+    end
   end
 
   local args = {}
   for _, dir in ipairs(source.exclude_directories or {}) do
-    table.insert(args, "--glob"); table.insert(args, "!" .. dir)
+    table.insert(args, "--glob")
+    table.insert(args, "!" .. dir)
   end
   for _, ext in ipairs(source.include_extensions or {}) do
-    table.insert(args, "-g"); table.insert(args, "*." .. ext)
+    table.insert(args, "-g")
+    table.insert(args, "*." .. ext)
   end
 
   local grep_opts = {
@@ -167,7 +187,9 @@ function M.run_grep(spec, source)
         actions.close(bufnr)
         local e = action_state.get_selected_entry()
         if e and spec.on_confirm then
-          vim.schedule(function() spec.on_confirm({ filename = e.filename, lnum = e.lnum, col = e.col }) end)
+          vim.schedule(function()
+            spec.on_confirm({ filename = e.filename, lnum = e.lnum, col = e.col })
+          end)
         end
       end)
       return true
@@ -178,12 +200,15 @@ function M.run_grep(spec, source)
     local default_maker = make_entry.gen_from_vimgrep(spec)
     grep_opts.entry_maker = function(line)
       local entry = default_maker(line)
-      if not entry then return nil end
+      if not entry then
+        return nil
+      end
       local disp_path = (spec.transform_display and spec.transform_display(entry.filename)) or entry.filename
       local disp_text = string.format("%s:%s:%s:%s", disp_path, entry.lnum, entry.col, entry.text)
       if use_devicons then
         local icon, hl = devicons.get_icon(entry.filename, vim.fn.fnamemodify(entry.filename, ":e"))
-        entry.display, entry.icon, entry.icon_hl, entry.display_text = make_display, icon or "", hl or "Normal", disp_text
+        entry.display, entry.icon, entry.icon_hl, entry.display_text =
+          make_display, icon or "", hl or "Normal", disp_text
       else
         entry.display = disp_text
       end
@@ -205,12 +230,14 @@ function M.run_callback(spec, source)
   local use_devicons = spec.devicons_enabled ~= false and devicons_ok
 
   local results = {}
-  
+
   -- ★ 修正: callback 用にも displayer を準備する
   local displayer, make_display
   if use_devicons then
     displayer = entry_display.create({ separator = " ", items = { { width = 2 }, { remaining = true } } })
-    make_display = function(entry) return displayer({ { entry.icon, entry.icon_hl }, entry.display_text }) end
+    make_display = function(entry)
+      return displayer({ { entry.icon, entry.icon_hl }, entry.display_text })
+    end
   end
 
   local entry_maker = create_entry_maker(spec, use_devicons, devicons, make_display)
@@ -219,10 +246,14 @@ function M.run_callback(spec, source)
     __call = function(_, _, cb, cb_complete)
       for _, item in ipairs(results) do
         local e = entry_maker(item)
-        if e then cb(e) end
+        if e then
+          cb(e)
+        end
       end
-      if cb_complete then cb_complete() end
-    end
+      if cb_complete then
+        cb_complete()
+      end
+    end,
   })
 
   local picker = pickers.new({
@@ -233,23 +264,54 @@ function M.run_callback(spec, source)
     sorting_strategy = "ascending",
     attach_mappings = function(bufnr)
       actions.select_default:replace(function()
-        local selection = action_state.get_selected_entry()
-        actions.close(bufnr)
-        if selection and spec.on_confirm then
-          vim.schedule(function() spec.on_confirm(selection.value) end)
+        local picker = action_state.get_current_picker(prompt_bufnr)
+        actions.close(prompt_bufnr)
+        local get_value = function(entry)
+          return entry and entry.value or nil
+        end
+        local is_multi = (spec.multiselect == "native" or spec.multiselect == true)
+        if is_multi then
+          local results = {}
+          for _, entry in ipairs(picker:get_multi_selection()) do
+            table.insert(results, get_value(entry))
+          end
+          if #results == 0 then
+            local e = action_state.get_selected_entry()
+            if e then
+              table.insert(results, get_value(e))
+            end
+          end
+          if spec.on_confirm then
+            vim.schedule(function()
+              spec.on_confirm(results)
+            end)
+          end
+        else
+          local e = action_state.get_selected_entry()
+          if spec.on_confirm then
+            vim.schedule(function()
+              spec.on_confirm(get_value(e))
+            end)
+          end
         end
       end)
       return true
     end,
   })
-  picker.tiebreak = function() return false end
+  picker.tiebreak = function()
+    return false
+  end
   picker:find()
 
   local push = function(items)
-    if not items then return end
-    local to_add = (type(items) == "table" and items[1] ~= nil) and items or {items}
-    for _, it in ipairs(to_add) do table.insert(results, it) end
-    
+    if not items then
+      return
+    end
+    local to_add = (type(items) == "table" and items[1] ~= nil) and items or { items }
+    for _, it in ipairs(to_add) do
+      table.insert(results, it)
+    end
+
     -- UIの更新を依頼
     vim.schedule(function()
       if picker.prompt_bufnr and vim.api.nvim_buf_is_valid(picker.prompt_bufnr) then
@@ -261,7 +323,9 @@ function M.run_callback(spec, source)
     end)
   end
 
-  if source.fn then source.fn(push) end
+  if source.fn then
+    source.fn(push)
+  end
 end
 
 function M.run_job(spec, source)
@@ -292,7 +356,9 @@ function M.run_job(spec, source)
         actions.close(bufnr)
         local selection = action_state.get_selected_entry()
         if selection and spec.on_confirm then
-          vim.schedule(function() spec.on_confirm(selection.value) end)
+          vim.schedule(function()
+            spec.on_confirm(selection.value)
+          end)
         end
       end)
       return true


### PR DESCRIPTION
Provide a fix for https://github.com/taku25/UNL.nvim/issues/9.

Should also fix an inconsistency between fzf-lua and telescope vs snacks : multiselect was an option for `run_callback` only for snacks. Now it should work with fzf-lua and telescope.