### PR TITLE
fix: resolve double leading slash in PATH_CTE on Linux

### DIFF
--- a/scanner/src/db/path.rs
+++ b/scanner/src/db/path.rs
@@ -79,7 +79,7 @@ pub const PATH_CTE: &str = "
     WITH RECURSIVE dir_paths(id, full_path) AS (
         SELECT d.id, s.text FROM directories d JOIN strings s ON d.name_id = s.id WHERE d.parent_id IS NULL
         UNION ALL
-        SELECT d.id, dp.full_path || '/' || s.text
+        SELECT d.id, CASE WHEN dp.full_path = '/' THEN '/' || s.text ELSE dp.full_path || '/' || s.text END
         FROM directories d
         JOIN dir_paths dp ON d.parent_id = dp.id
         JOIN strings s ON d.name_id = s.id


### PR DESCRIPTION
On Linux, path components are stored individually in the directory tree. The root directory '/' is stored as a single slash, but when the recursive CTE reconstructs the full path it concatenates with another '/' producing '//home/...' instead of '/home/...'.

This caused find_module_for_path() to fail silently because the normalized file path (/home/...) never matched the stored module_root (//home/...), making goto_definition and open_file fall back to LSP which was not active.

Fix: use CASE WHEN in PATH_CTE to avoid double slash when full_path is '/'. This correctly handles Linux/macOS absolute paths while preserving Windows UNC paths (//server/share) and drive letters (C:/...).